### PR TITLE
dh: add NIKE adapter; drive NK1 with X25519-CTIDH1024

### DIFF
--- a/dh/nike.go
+++ b/dh/nike.go
@@ -1,0 +1,115 @@
+// SPDX-FileCopyrightText: Copyright (C) 2026 David Stainton
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package dh
+
+import (
+	"io"
+
+	"github.com/katzenpost/hpqc/nike"
+)
+
+// FromNIKE returns a DH that wraps an hpqc nike.Scheme. This permits the
+// use of arbitrary NIKE schemes, including post-quantum hybrids such as
+// X25519-CTIDH1024, with classical Noise patterns (NK, NK1, XX, XK, ...).
+//
+// DHLEN is taken from the scheme's public key size. The shared secret
+// returned by DH() is whatever the scheme's DeriveSecret returns; for a
+// hybrid NIKE this is the concatenation of each component's shared secret.
+func FromNIKE(scheme nike.Scheme) DH {
+	return &nikeDH{scheme: scheme}
+}
+
+type nikeDH struct {
+	scheme nike.Scheme
+}
+
+func (n *nikeDH) String() string {
+	return n.scheme.Name()
+}
+
+func (n *nikeDH) GenerateKeypair(rng io.Reader) (Keypair, error) {
+	_, priv, err := n.scheme.GenerateKeyPairFromEntropy(rng)
+	if err != nil {
+		return nil, err
+	}
+	return &nikeKeypair{scheme: n.scheme, priv: priv}, nil
+}
+
+func (n *nikeDH) ParsePrivateKey(data []byte) (Keypair, error) {
+	priv, err := n.scheme.UnmarshalBinaryPrivateKey(data)
+	if err != nil {
+		return nil, ErrMalformedPrivateKey
+	}
+	return &nikeKeypair{scheme: n.scheme, priv: priv}, nil
+}
+
+func (n *nikeDH) ParsePublicKey(data []byte) (PublicKey, error) {
+	pub, err := n.scheme.UnmarshalBinaryPublicKey(data)
+	if err != nil {
+		return nil, ErrMalformedPublicKey
+	}
+	return &nikePublicKey{scheme: n.scheme, pub: pub}, nil
+}
+
+func (n *nikeDH) Size() int {
+	return n.scheme.PublicKeySize()
+}
+
+type nikeKeypair struct {
+	scheme nike.Scheme
+	priv   nike.PrivateKey
+}
+
+func (kp *nikeKeypair) MarshalBinary() ([]byte, error) {
+	return kp.priv.MarshalBinary()
+}
+
+func (kp *nikeKeypair) UnmarshalBinary(data []byte) error {
+	priv, err := kp.scheme.UnmarshalBinaryPrivateKey(data)
+	if err != nil {
+		return ErrMalformedPrivateKey
+	}
+	kp.priv = priv
+	return nil
+}
+
+func (kp *nikeKeypair) DropPrivate() {
+	if kp.priv != nil {
+		kp.priv.Reset()
+	}
+}
+
+func (kp *nikeKeypair) Public() PublicKey {
+	return &nikePublicKey{scheme: kp.scheme, pub: kp.priv.Public()}
+}
+
+func (kp *nikeKeypair) DH(publicKey PublicKey) ([]byte, error) {
+	pk, ok := publicKey.(*nikePublicKey)
+	if !ok {
+		return nil, ErrMismatchedPublicKey
+	}
+	return kp.scheme.DeriveSecret(kp.priv, pk.pub), nil
+}
+
+type nikePublicKey struct {
+	scheme nike.Scheme
+	pub    nike.PublicKey
+}
+
+func (pk *nikePublicKey) MarshalBinary() ([]byte, error) {
+	return pk.pub.MarshalBinary()
+}
+
+func (pk *nikePublicKey) UnmarshalBinary(data []byte) error {
+	pub, err := pk.scheme.UnmarshalBinaryPublicKey(data)
+	if err != nil {
+		return ErrMalformedPublicKey
+	}
+	pk.pub = pub
+	return nil
+}
+
+func (pk *nikePublicKey) Bytes() []byte {
+	return pk.pub.Bytes()
+}

--- a/example_nike_test.go
+++ b/example_nike_test.go
@@ -1,0 +1,108 @@
+// SPDX-FileCopyrightText: Copyright (C) 2026 David Stainton
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package nyquist
+
+import (
+	"crypto/rand"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/katzenpost/hpqc/nike/hybrid"
+
+	"github.com/katzenpost/nyquist/cipher"
+	"github.com/katzenpost/nyquist/dh"
+	"github.com/katzenpost/nyquist/hash"
+	"github.com/katzenpost/nyquist/pattern"
+)
+
+// TestNK1HybridNIKE drives the classical NK1 Noise pattern with a hybrid
+// post-quantum NIKE (X25519-CTIDH1024) supplied via dh.FromNIKE.
+func TestNK1HybridNIKE(t *testing.T) {
+	require := require.New(t)
+
+	protocol := &Protocol{
+		Pattern: pattern.NK1,
+		DH:      dh.FromNIKE(hybrid.X25519CTIDH1024),
+		Cipher:  cipher.ChaChaPoly,
+		Hash:    hash.BLAKE2s,
+	}
+
+	bobStatic, err := protocol.DH.GenerateKeypair(rand.Reader)
+	require.NoError(err, "Generate Bob's static keypair")
+
+	aliceCfg := &HandshakeConfig{
+		Protocol: protocol,
+		DH: &DHConfig{
+			RemoteStatic: bobStatic.Public(),
+		},
+		IsInitiator: true,
+	}
+	bobCfg := &HandshakeConfig{
+		Protocol: protocol,
+		DH: &DHConfig{
+			LocalStatic: bobStatic,
+		},
+		IsInitiator: false,
+	}
+
+	aliceHs, err := NewHandshake(aliceCfg)
+	require.NoError(err, "NewHandshake(aliceCfg)")
+	defer aliceHs.Reset()
+
+	bobHs, err := NewHandshake(bobCfg)
+	require.NoError(err, "NewHandshake(bobCfg)")
+	defer bobHs.Reset()
+
+	// NK1: -> e
+	alicePayload := []byte("alice -> e")
+	aliceMsg1, err := aliceHs.WriteMessage(nil, alicePayload)
+	require.NoError(err, "aliceHs.WriteMessage(1)")
+
+	bobRecv, err := bobHs.ReadMessage(nil, aliceMsg1)
+	require.NoError(err, "bobHs.ReadMessage(1)")
+	require.Equal(alicePayload, bobRecv)
+
+	// NK1: <- e, ee, es  (handshake completes here)
+	bobPayload := []byte("bob -> e, ee, es")
+	bobMsg1, err := bobHs.WriteMessage(nil, bobPayload)
+	require.Equal(ErrDone, err, "bobHs.WriteMessage(2)")
+
+	aliceRecv, err := aliceHs.ReadMessage(nil, bobMsg1)
+	require.Equal(ErrDone, err, "aliceHs.ReadMessage(2)")
+	require.Equal(bobPayload, aliceRecv)
+
+	aliceStatus := aliceHs.GetStatus()
+	bobStatus := bobHs.GetStatus()
+
+	require.Equal(aliceStatus.HandshakeHash, bobStatus.HandshakeHash, "Handshake hashes match")
+	require.Equal(aliceStatus.DH.LocalEphemeral.Bytes(), bobStatus.DH.RemoteEphemeral.Bytes())
+	require.Equal(bobStatus.DH.LocalEphemeral.Bytes(), aliceStatus.DH.RemoteEphemeral.Bytes())
+	require.Equal(aliceStatus.DH.RemoteStatic.Bytes(), bobStatic.Public().Bytes())
+
+	aliceTx, aliceRx := aliceStatus.CipherStates[0], aliceStatus.CipherStates[1]
+	bobRx, bobTx := bobStatus.CipherStates[0], bobStatus.CipherStates[1]
+	defer func() {
+		aliceTx.Reset()
+		aliceRx.Reset()
+		bobTx.Reset()
+		bobRx.Reset()
+	}()
+
+	plaintext := []byte("hello via NK1 over X25519-CTIDH1024")
+	ct, err := aliceTx.EncryptWithAd(nil, nil, plaintext)
+	require.NoError(err, "aliceTx.EncryptWithAd")
+
+	pt, err := bobRx.DecryptWithAd(nil, nil, ct)
+	require.NoError(err, "bobRx.DecryptWithAd")
+	require.Equal(plaintext, pt)
+
+	ack := []byte("ack")
+	ct2, err := bobTx.EncryptWithAd(nil, nil, ack)
+	require.NoError(err, "bobTx.EncryptWithAd")
+
+	pt2, err := aliceRx.DecryptWithAd(nil, nil, ct2)
+	require.NoError(err, "aliceRx.DecryptWithAd")
+	require.Equal(ack, pt2)
+}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/katzenpost/nyquist
 go 1.26.2
 
 require (
-	github.com/katzenpost/hpqc v0.0.76
+	github.com/katzenpost/hpqc v0.0.78
 	github.com/oasisprotocol/deoxysii v0.0.0-20220228165953-2091330c22b7
 	github.com/rfjakob/eme v1.1.2
 	github.com/stretchr/testify v1.8.4
@@ -16,7 +16,6 @@ require (
 	codeberg.org/vula/highctidh v1.0.2025051200 // indirect
 	filippo.io/mlkem768 v0.0.0-20260214141301-2e7bebc7d88d // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/go-faster/xor v1.0.0 // indirect
 	github.com/katzenpost/chacha20 v0.0.1 // indirect
 	github.com/katzenpost/circl v1.3.8-0.20260413165442-e2d217fd59f5 // indirect
 	github.com/katzenpost/sntrup4591761 v0.0.0-20231024131303-8755eb1986b8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -5,14 +5,12 @@ filippo.io/mlkem768 v0.0.0-20260214141301-2e7bebc7d88d/go.mod h1:ym4egWKLpazdho3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/go-faster/xor v1.0.0 h1:2o8vTOgErSGHP3/7XwA5ib1FTtUsNtwCoLLBjl31X38=
-github.com/go-faster/xor v1.0.0/go.mod h1:x5CaDY9UKErKzqfRfFZdfu+OSTfoZny3w5Ak7UxcipQ=
 github.com/katzenpost/chacha20 v0.0.1 h1:Scu6Pqyginw083FhypKMIBmCI2gQTC1RFD6vqpWwI2Y=
 github.com/katzenpost/chacha20 v0.0.1/go.mod h1:/LIJK/8cUXVJrCh5NypZ8So3gDfQCoQT8lRvy1rYQZA=
 github.com/katzenpost/circl v1.3.8-0.20260413165442-e2d217fd59f5 h1:n+9aUwSmnz97MNS9duYeHSq+s42CG9wydFECOjqAI9A=
 github.com/katzenpost/circl v1.3.8-0.20260413165442-e2d217fd59f5/go.mod h1:9KxLMK17ZLjofnmpVp4Sm315uIF3BAWHVk32EFDRicU=
-github.com/katzenpost/hpqc v0.0.76 h1:ZhUkvbSJnLDQt9URJVNo6CuzFl1GIheNG4rAzom1kdM=
-github.com/katzenpost/hpqc v0.0.76/go.mod h1:A9ftm1U7h1pTbhFqP/Scp1CnGN6YkK5UXWtWQVKEgPU=
+github.com/katzenpost/hpqc v0.0.78 h1:SJcrDvdS4gUh1hQuDEHDMSjg72brpJh8ySe4N3tJqkQ=
+github.com/katzenpost/hpqc v0.0.78/go.mod h1:A9ftm1U7h1pTbhFqP/Scp1CnGN6YkK5UXWtWQVKEgPU=
 github.com/katzenpost/sntrup4591761 v0.0.0-20231024131303-8755eb1986b8 h1:TsKxH0x2RUwf5rBw67k15bqVM3oVbexA9oaTZQLIy3Y=
 github.com/katzenpost/sntrup4591761 v0.0.0-20231024131303-8755eb1986b8/go.mod h1:Hmcrwom7jcEmGdo0CsyuJNnldPeyS+M07FuCbo7I8fw=
 github.com/mattn/go-pointer v0.0.1 h1:n+XhsuGeVO6MEAp7xyEukFINEa+Quek5psIR/ylA6o0=


### PR DESCRIPTION
## Summary

- Introduce `dh.FromNIKE`, a thin wrapper that adapts an hpqc `nike.Scheme` to nyquist's `dh.DH` interface. This permits any NIKE, including the post-quantum hybrids in `hpqc/nike/hybrid` (CTIDH1024-X25519, X25519-CTIDH1024, CTIDH512-X448, and so forth), to be plugged into the classical Noise patterns (NK, NK1, XX, XK, ...) without recourse to the `Pq*` KEM-flavoured patterns.
- Add `TestNK1HybridNIKE` exercising the full NK1 exchange and a round of post-handshake transport encryption using `hybrid.X25519CTIDH1024`.
- Bump the `hpqc` dependency to `v0.0.78`, the first tag containing the `X25519-CTIDH1024` alias.

## Design notes

`DHLEN` is taken from `nike.Scheme.PublicKeySize()`. The shared secret returned by `DH()` is whatever `nike.Scheme.DeriveSecret` returns; for a hybrid NIKE this is the concatenation of the component shared secrets, which `MixKey` then folds into the symmetric state via the CKDF. No changes are required to the handshake state machine; the adapter is purely a `dh.DH` implementation.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` (existing suite, including vectors)
- [x] `go test -run TestNK1HybridNIKE -v .` (new test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)